### PR TITLE
Define a general SHELL environment variable for the system

### DIFF
--- a/gcs/newfiles_skel/etc/profile.d/lxterminal.sh
+++ b/gcs/newfiles_skel/etc/profile.d/lxterminal.sh
@@ -1,0 +1,5 @@
+
+# LXTerminal needs a SHELL environment variable defined
+# and this variable is not defined when a user logs in the system
+# by using Active Directory authentication
+SHELL="/bin/bash"


### PR DESCRIPTION
Necessary for LXTerminal when using Active Directory authentication method.